### PR TITLE
Rethrow execution error with errInfo

### DIFF
--- a/lib/actions/up.js
+++ b/lib/actions/up.js
@@ -1,22 +1,24 @@
 const _ = require("lodash");
 const pEachSeries = require("p-each-series");
 const { promisify } = require("util");
-const fnArgs = require('fn-args');
+const fnArgs = require("fn-args");
 
 const status = require("./status");
 const config = require("../env/config");
 const migrationsDir = require("../env/migrationsDir");
-const hasCallback = require('../utils/has-callback');
+const hasCallback = require("../utils/has-callback");
 
 module.exports = async (db, client) => {
   const statusItems = await status(db);
   const pendingItems = _.filter(statusItems, { appliedAt: "PENDING" });
   const migrated = [];
 
-  const migrateItem = async item => {
+  const migrateItem = async (item) => {
     try {
       const migration = await migrationsDir.loadMigration(item.fileName);
-      const up = hasCallback(migration.up) ? promisify(migration.up) : migration.up;
+      const up = hasCallback(migration.up)
+        ? promisify(migration.up)
+        : migration.up;
 
       if (hasCallback(migration.up) && fnArgs(migration.up).length < 3) {
         // support old callback-based migrations prior to migrate-mongo 7.x.x
@@ -24,13 +26,13 @@ module.exports = async (db, client) => {
       } else {
         await up(db, client);
       }
-
     } catch (err) {
       const error = new Error(
-        `Could not migrate up ${item.fileName}: ${err.message}`
+        `Could not migrate up ${item.fileName}: ${err.message}`,
       );
       error.stack = err.stack;
       error.migrated = migrated;
+      error.additionalInfo = err.errInfo;
       throw error;
     }
 
@@ -41,7 +43,11 @@ module.exports = async (db, client) => {
     const appliedAt = new Date();
 
     try {
-      await changelogCollection.insertOne(useFileHash === true ? { fileName, fileHash, appliedAt } : { fileName, appliedAt });
+      await changelogCollection.insertOne(
+        useFileHash === true
+          ? { fileName, fileHash, appliedAt }
+          : { fileName, appliedAt },
+      );
     } catch (err) {
       throw new Error(`Could not update changelog: ${err.message}`);
     }


### PR DESCRIPTION
Add errInfo as additionalInfo when error occurs executing up

##### Checklist
- [x] `npm test` passes and has 100% coverage
- [x] README.md is updated
